### PR TITLE
Wear spacesuit accounting for server lag

### DIFF
--- a/drowning.lua
+++ b/drowning.lua
@@ -29,7 +29,7 @@ minetest.register_globalstep(function(dtime)
 				for i, stack in pairs(armor_inv:get_list("armor")) do
 					if not stack:is_empty() then
 						local name = stack:get_name()
-						local use = minetest.get_item_group(name, "armor_use") or 0
+						local use = minetest.get_item_group(name, "armor_use") * timer or 0
 						armor:damage(player, i, stack, use)
 					end
 				end
@@ -39,10 +39,10 @@ minetest.register_globalstep(function(dtime)
 		end
 		timer = 0
 
-	        local t1 = minetest.get_us_time()
-	        local diff = t1 - t0
-	        if diff > 10000 then
-	                minetest.log("warning", "[spacesuit] update took " .. diff .. " us")
-	        end
+		local t1 = minetest.get_us_time()
+		local diff = t1 - t0
+		if diff > 10000 then
+			minetest.log("warning", "[spacesuit] update took " .. diff .. " us")
+		end
 	end
 end)

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 
 spacesuit = {
-	armor_use = tonumber(minetest.settings:get("spacesuit.armor_use")) or 75,
+	armor_use = tonumber(minetest.settings:get("spacesuit.armor_use")) or 70,
 }
 
 


### PR DESCRIPTION
This makes spacesuit wear independent from server lag. The timer between updates should average one second. If it is more, multiplying by the timer value increases wear as if an update had happened at every additional step (except the wear value would be rounded to an integer between 0 and 65535 every time).

Because the real average is slightly higher than one second, multiplying by the timer value (what this change does) decreases how long the spacesuit lasts. With one additional step per update and steps of 0.034 seconds (the average time I get in singleplayer), that means 2 or 3 additional wear. So I also decrease armor_use to 70, which restores the spacesuit to lasting as long as before or slightly longer.

Also, this allows increasing the minimum timer value to two seconds or more without needing to change the armor_use value.