### PR TITLE
Replace air bottle by empty bottle when repairing spacesuit

### DIFF
--- a/repair.lua
+++ b/repair.lua
@@ -9,6 +9,9 @@ if has_vacuum then
 			recipe = {
 				"vacuum:air_bottle",
 				partname
+			},
+			replacements = {
+				{"vacuum:air_bottle", "vessels:steel_bottle"}
 			}
 		})
 	end


### PR DESCRIPTION
When you repair a spacesuit part by crafting it with an air bottle, you lose the air bottle. This fixes that by giving the empty heavy iron bottle back.

![step1](https://user-images.githubusercontent.com/51716565/60405764-cba2e100-9ba1-11e9-820b-8d51e1dc1f5c.png)
![step2](https://user-images.githubusercontent.com/51716565/60405766-cf366800-9ba1-11e9-817b-d0b80cf1a220.png)
