### PR TITLE
Make spacesuit not repairable by the anvil or the tool workshop

### DIFF
--- a/suit.lua
+++ b/suit.lua
@@ -5,6 +5,7 @@ armor:register_armor("spacesuit:helmet", {
 	inventory_image = "spacesuit_inv_helmet.png",
 	groups = {armor_head=5, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
+	wear_represents = "spacesuit_wear",
 })
 
 minetest.register_tool("spacesuit:chestplate", {
@@ -12,6 +13,7 @@ minetest.register_tool("spacesuit:chestplate", {
 	inventory_image = "spacesuit_inv_chestplate.png",
 	groups = {armor_torso=8, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
+	wear_represents = "spacesuit_wear",
 })
 
 minetest.register_tool("spacesuit:pants", {
@@ -19,6 +21,7 @@ minetest.register_tool("spacesuit:pants", {
 	inventory_image = "spacesuit_inv_pants.png",
 	groups = {armor_legs=7, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
+	wear_represents = "spacesuit_wear",
 })
 
 minetest.register_tool("spacesuit:boots", {
@@ -26,4 +29,5 @@ minetest.register_tool("spacesuit:boots", {
 	inventory_image = "spacesuit_inv_boots.png",
 	groups = {armor_feet=4, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
+	wear_represents = "spacesuit_wear",
 })

--- a/suit.lua
+++ b/suit.lua
@@ -3,27 +3,27 @@
 armor:register_armor("spacesuit:helmet", {
 	description = "Spacesuit Helmet",
 	inventory_image = "spacesuit_inv_helmet.png",
-	groups = {armor_head=5, armor_heal=1, armor_use=spacesuit.armor_use},
+	groups = {armor_head=5, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
 })
 
 minetest.register_tool("spacesuit:chestplate", {
 	description = "Spacesuit Chestplate",
 	inventory_image = "spacesuit_inv_chestplate.png",
-	groups = {armor_torso=8, armor_heal=1, armor_use=spacesuit.armor_use},
+	groups = {armor_torso=8, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
 })
 
 minetest.register_tool("spacesuit:pants", {
 	description = "Spacesuit Pants",
 	inventory_image = "spacesuit_inv_pants.png",
-	groups = {armor_legs=7, armor_heal=1, armor_use=spacesuit.armor_use},
+	groups = {armor_legs=7, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
 })
 
 minetest.register_tool("spacesuit:boots", {
 	description = "Spacesuit Boots",
 	inventory_image = "spacesuit_inv_boots.png",
-	groups = {armor_feet=4, armor_heal=1, armor_use=spacesuit.armor_use},
+	groups = {armor_feet=4, armor_heal=1, armor_use=spacesuit.armor_use, not_repaired_by_anvil=1},
 	wear = 0,
 })


### PR DESCRIPTION
This means the spacesuit's oxygen can only be replenished with the air pump (which can be automated) or air bottles, and in any case not by hammering it on an anvil.