### PR TITLE
Suffocate faster without spacesuit + damage from 8df57b3

### DIFF
--- a/drowning.lua
+++ b/drowning.lua
@@ -35,16 +35,25 @@ minetest.register_globalstep(function(dtime)
 				end
 
 				player:set_breath(10)
-			end
 
-		-- check if player is in vacuum without spacesuit
-		local ppos = player:get_pos()
-		local is_admin = minetest.check_player_privs(player:get_player_name(), "privs")
-		local node = minetest.get_node(ppos)
-		if node.name == "vacuum:vacuum" and not has_full_suit and not is_admin then
-			-- player does not wear a suit, let him/her suffer!
-			player:set_hp( player:get_hp() - 2, "drown" )
-		end
+			elseif not has_full_suit then
+				-- check if player is in vacuum without spacesuit
+				local is_admin = minetest.check_player_privs(player:get_player_name(), "privs")
+				if not is_admin then
+					local ppos = player:get_pos()
+					local node = minetest.get_node(ppos)
+					if node.name == "vacuum:vacuum" then
+						-- player does not wear a suit, let him/her suffer!
+						local breath = player:get_breath()
+						if breath > 0 then
+							player:set_breath(math.max(0, player:get_breath() - 4))
+						end
+						if  breath < 4 then
+							player:set_hp( player:get_hp() - 2, "drown" )
+						end
+					end
+				end
+			end
 
 		end
 		timer = 0


### PR DESCRIPTION
So here's proposal for combined fast suffocation and extra drowning damage 8df57b3
https://github.com/pandorabox-io/pandorabox.io/issues/434

I think abnormally fast suffocation (which is normal in vacuum btw) is important because it gives clear hint to player about what is actually happening.